### PR TITLE
Add missing patches

### DIFF
--- a/Classes/DirectMailUtility.php
+++ b/Classes/DirectMailUtility.php
@@ -30,7 +30,10 @@ use TYPO3\CMS\Core\Resource\FileRepository;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Core\Http\ServerRequestFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 
 /**
  * Static class.
@@ -96,6 +99,22 @@ class DirectMailUtility
     ): string {
         $typolinkPageUrl = 't3://page?uid=';
         $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+        // Ensure a PSR-7 request is available for ContentObjectRenderer when running in CLI/Scheduler
+        if (!empty($GLOBALS['TYPO3_REQUEST'])) {
+            $cObj->setRequest($GLOBALS['TYPO3_REQUEST']);
+        } else {
+            try {
+                $requestFactory = GeneralUtility::makeInstance(ServerRequestFactory::class);
+                $request = $requestFactory->fromGlobals();
+                // Provide applicationType so ApplicationType::fromRequest() can detect BE/FE
+                $request = $request->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+                $GLOBALS['TYPO3_REQUEST'] = $request;
+                $cObj->setRequest($request);
+            } catch (\Throwable $e) {
+                // ignore: if we cannot create a request, typolink may still fail later
+            }
+        }
 
         return $cObj->typolink_URL([
             'parameter' => $typolinkPageUrl . $parameter,
@@ -301,7 +320,8 @@ class DirectMailUtility
     public static function getFullUrlsForDirectMailRecord(array $row): array
     {
         // Finding the domain to use
-        if (!$_SERVER['HTTP_HOST']) {
+        // Use empty() to avoid "Undefined array key" when running in CLI/Scheduler
+        if (empty($_SERVER['HTTP_HOST'])) {
             // In CLI / Scheduler context, $_SERVER['HTTP_HOST'] can be null
             $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
             $site = $siteFinder->getSiteByPageId((int)$row['page']);

--- a/Classes/Dmailer.php
+++ b/Classes/Dmailer.php
@@ -391,7 +391,7 @@ class Dmailer implements LoggerAwareInterface
 
             $this->theParts['html']['content'] = '';
             if ($this->flagHtml && (($recipientRow['module_sys_dmail_html'] ?? false) || $tableNameChar == 'P')) {
-                $tempContentHTML = $this->getBoundaryParts($this->dmailer['boundaryParts_html'], $recipientRow['sys_dmail_categories_list']);
+                $tempContentHTML = $this->getBoundaryParts($this->dmailer['boundaryParts_html'], $recipientRow['sys_dmail_categories_list'] ?? '');
                 if ($this->mailHasContent) {
                     $this->theParts['html']['content'] = $this->replaceMailMarkers($tempContentHTML, $recipientRow, $additionalMarkers);
                     $returnCode |= 1;
@@ -401,7 +401,7 @@ class Dmailer implements LoggerAwareInterface
             // Plain
             $this->theParts['plain']['content'] = '';
             if ($this->flagPlain) {
-                $tempContentPlain = $this->getBoundaryParts($this->dmailer['boundaryParts_plain'], $recipientRow['sys_dmail_categories_list']);
+                $tempContentPlain = $this->getBoundaryParts($this->dmailer['boundaryParts_plain'], $recipientRow['sys_dmail_categories_list'] ?? '');
                 if ($this->mailHasContent) {
                     $tempContentPlain = $this->replaceMailMarkers($tempContentPlain, $recipientRow, $additionalMarkers);
                     if (trim($this->dmailer['sys_dmail_rec']['use_rdct']) || trim($this->dmailer['sys_dmail_rec']['long_link_mode'])) {

--- a/Classes/Dmailer.php
+++ b/Classes/Dmailer.php
@@ -840,7 +840,7 @@ class Dmailer implements LoggerAwareInterface
             $this->extractMediaLinks();
             foreach ($this->theParts['html']['media'] as $media) {
                 // TODO: why are there table related tags here?
-                if (in_array($media['tag'], ['img', 'table', 'tr', 'td'], true) && !$media['use_jumpurl'] && !$media['do_not_embed']) {
+                if (isset($media['tag']) && in_array($media['tag'], ['img', 'table', 'tr', 'td'], true) && !$media['use_jumpurl'] && !$media['do_not_embed']) {
                     if (ini_get('allow_url_fopen')) {
                         $context = GeneralUtility::makeInstance(FetchUtility::class)->getStreamContext();
                         if (($fp = fopen($media['absRef'], 'r', false, $context)) !== false) {

--- a/Classes/Module/MailerEngineController.php
+++ b/Classes/Module/MailerEngineController.php
@@ -8,6 +8,8 @@ use DirectMailTeam\DirectMail\Dmailer;
 use DirectMailTeam\DirectMail\Repository\SysDmailMaillogRepository;
 use DirectMailTeam\DirectMail\Repository\SysDmailRepository;
 use DirectMailTeam\DirectMail\Utility\SchedulerUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
@@ -21,8 +23,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\Pagination\ArrayPaginator;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 
 final class MailerEngineController extends MainController
 {
@@ -154,9 +155,9 @@ final class MailerEngineController extends MainController
 
     protected function getSchedulerTable(): array
     {
-        $schedulerTable = ['taskGroupsWithTasks' => [], 'errorClasses' => []];
+        $schedulerTable = [];
         if (ExtensionManagementUtility::isLoaded('scheduler')) {
-            $schedulerTable = SchedulerUtility::getDMTable();
+            $schedulerTable = GeneralUtility::makeInstance(SchedulerUtility::class)->getDMTable();
         }
         return $schedulerTable;
     }

--- a/Classes/Module/StatisticsController.php
+++ b/Classes/Module/StatisticsController.php
@@ -171,9 +171,9 @@ final class StatisticsController extends MainController
 
                     $itemsPerPage = 100; //@TODO
                     $paginator = GeneralUtility::makeInstance(
-                        ArrayPaginator::class, 
-                        $data['dataPageInfo'] ?? [], 
-                        $this->currentPageNumber, 
+                        ArrayPaginator::class,
+                        $data['dataPageInfo'] ?? [],
+                        $this->currentPageNumber,
                         $itemsPerPage
                     );
 
@@ -1653,11 +1653,11 @@ final class StatisticsController extends MainController
 
         }
 
-        if ($this->implodedParams['showContentTitle'] == 1) {
+        if (isset($this->implodedParams['showContentTitle']) && $this->implodedParams['showContentTitle'] == 1) {
             $label = $contentTitle;
         }
 
-        if ($this->implodedParams['prependContentTitle'] == 1) {
+        if (isset($this->implodedParams['prependContentTitle']) && $this->implodedParams['prependContentTitle'] == 1) {
             $label =  $contentTitle . ' (' . $linkedWord . ')';
         }
 

--- a/Classes/Module/StatisticsController.php
+++ b/Classes/Module/StatisticsController.php
@@ -171,9 +171,9 @@ final class StatisticsController extends MainController
 
                     $itemsPerPage = 100; //@TODO
                     $paginator = GeneralUtility::makeInstance(
-                        ArrayPaginator::class, 
-                        $data['dataPageInfo'] ?? [], 
-                        $this->currentPageNumber, 
+                        ArrayPaginator::class,
+                        $data['dataPageInfo'] ?? [],
+                        $this->currentPageNumber,
                         $itemsPerPage
                     );
 
@@ -1574,7 +1574,7 @@ final class StatisticsController extends MainController
                 $urlstr .= ($urlParts['fragment'] ?? '') ? '#' . $urlParts['fragment'] : '';
             }
         } else {
-            $urlstr =  ((isset($urlParts['host']) && $urlParts['host']) ? $urlParts['scheme'] . '://' . $urlParts['host'] : $baseUrl) . $urlParts['path'];
+            $urlstr =  ((isset($urlParts['host']) && $urlParts['host']) ? $urlParts['scheme'] . '://' . $urlParts['host'] : $baseUrl) . ($urlParts['path'] ?? '');
             $urlstr .= ($urlParts['query'] ?? '')    ? '?' . $urlParts['query']    : '';
             $urlstr .= ($urlParts['fragment'] ?? '') ? '#' . $urlParts['fragment'] : '';
         }

--- a/Classes/SelectCategories.php
+++ b/Classes/SelectCategories.php
@@ -17,6 +17,7 @@ namespace DirectMailTeam\DirectMail;
 
 use DirectMailTeam\DirectMail\Repository\TempRepository;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -39,7 +40,7 @@ class SelectCategories
         $lang = $this->getLang();
 
         $site = $params['site'];
-        $languages = $site->getAllLanguages();
+        $languages = ($site instanceof Site) ? $site->getAllLanguages() : [];
         foreach($languages as $language) {
             if($language->getLocale()->getLanguageCode() == $lang) {
                 $sysLanguageUid = $language->getLanguageId();

--- a/Classes/Utility/SchedulerUtility.php
+++ b/Classes/Utility/SchedulerUtility.php
@@ -12,6 +12,8 @@ namespace DirectMailTeam\DirectMail\Utility;
 
 use DirectMailTeam\DirectMail\Repository\TempRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Exception\InvalidTaskException;
+use TYPO3\CMS\Scheduler\ProgressProviderInterface;
 use TYPO3\CMS\Scheduler\Service\TaskService;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
 use TYPO3\CMS\Scheduler\Task\TaskSerializer;
@@ -19,15 +21,20 @@ use TYPO3\CMS\Scheduler\Validation\Validator\TaskValidator;
 
 class SchedulerUtility
 {
-    protected static function isValidTaskObject($task): bool
+    public function __construct(
+        protected readonly TaskSerializer $taskSerializer,
+        protected readonly TaskService $taskService,
+    ) {
+    }
+
+    protected function isValidTaskObject($task): bool
     {
         return (new TaskValidator())->isValid($task);
     }
 
-    public static function getDMTable(): array
+    public function getDMTable(): array
     {
-        $taskSerializer = GeneralUtility::makeInstance(TaskSerializer::class);
-        $registeredClasses = GeneralUtility::makeInstance(TaskService::class)->getAvailableTaskTypes();
+        $registeredClasses = $this->taskService->getAvailableTaskTypes();
 
         $tasks = GeneralUtility::makeInstance(TempRepository::class)->getDMTasks();
 
@@ -45,18 +52,18 @@ class SchedulerUtility
                 ];
 
                 try {
-                    $taskObject = $taskSerializer->deserialize($task['serialized_task_object']);
+                    $taskObject = $this->taskSerializer->deserialize($task['serialized_task_object']);
                 } catch (InvalidTaskException $e) {
                     $taskData['errorMessage'] = $e->getMessage();
-                    $taskData['class'] = $taskSerializer->extractClassName($task['serialized_task_object']);
+                    $taskData['class'] = $this->taskSerializer->extractClassName($task['serialized_task_object']);
                     $errorClasses[] = $taskData;
                     continue;
                 }
 
-                $taskClass = $taskSerializer->resolveClassName($taskObject);
+                $taskClass = $this->taskSerializer->resolveClassName($taskObject);
                 $taskData['class'] = $taskClass;
 
-                if (!self::isValidTaskObject($taskObject)) {
+                if (!$this->isValidTaskObject($taskObject)) {
                     $taskData['errorMessage'] = 'The class ' . $taskClass . ' is not a valid task';
                     $errorClasses[] = $taskData;
                     continue;
@@ -72,15 +79,6 @@ class SchedulerUtility
                     $taskData['progress'] = round((float)$taskObject->getProgress(), 2);
                 }
 
-                if (!isset($registeredClasses[$taskClass])) {
-                    $taskData['errorMessage'] = 'The class ' . $taskClass . ' is not a registered task';
-                    $errorClasses[] = $taskData;
-                    continue;
-                }
-
-                if ($taskObject instanceof ProgressProviderInterface) {
-                    $taskData['progress'] = round((float)$taskObject->getProgress(), 2);
-                }
                 $taskData['classTitle'] = $registeredClasses[$taskClass]['title'];
                 $taskData['classExtension'] = $registeredClasses[$taskClass]['extension'];
                 $taskData['additionalInformation'] = $taskObject->getAdditionalInformation();
@@ -89,17 +87,21 @@ class SchedulerUtility
                 $taskData['nextExecution'] = (int)$task['nextexecution'];
                 $taskData['type'] = 'single';
                 $taskData['frequency'] = '';
+
                 if ($taskObject->getType() === AbstractTask::TYPE_RECURRING) {
                     $taskData['type'] = 'recurring';
                     $taskData['frequency'] = $taskObject->getExecution()->getCronCmd() ?: $taskObject->getExecution()->getInterval();
                 }
+
                 $taskData['multiple'] = (bool)$taskObject->getExecution()->getMultiple();
                 $taskData['lastExecutionFailure'] = false;
+
                 if (!empty($task['lastexecution_failure'])) {
                     $taskData['lastExecutionFailure'] = true;
                     $exceptionArray = @unserialize($task['lastexecution_failure']);
                     $taskData['lastExecutionFailureCode'] = '';
                     $taskData['lastExecutionFailureMessage'] = '';
+
                     if (is_array($exceptionArray)) {
                         $taskData['lastExecutionFailureCode'] = $exceptionArray['code'];
                         $taskData['lastExecutionFailureMessage'] = $exceptionArray['message'];
@@ -108,6 +110,7 @@ class SchedulerUtility
 
                 // If a group is deleted or no group is set it needs to go into "not assigned groups"
                 $groupIndex = $task['isTaskGroupDeleted'] === 1 || $task['isTaskGroupDeleted'] === null ? 0 : (int)$task['task_group'];
+
                 if (!isset($taskGroupsWithTasks[$groupIndex])) {
                     $taskGroupsWithTasks[$groupIndex] = [
                         'tasks' => [],
@@ -117,6 +120,7 @@ class SchedulerUtility
                         'groupHidden' => $task['isTaskGroupHidden'],
                     ];
                 }
+
                 $taskGroupsWithTasks[$groupIndex]['tasks'][] = $taskData;
             }
         }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,6 +7,9 @@ services:
   DirectMailTeam\DirectMail\:
     resource: '../Classes/*'
 
+  DirectMailTeam\DirectMail\Utility\SchedulerUtility:
+    public: true
+
   DirectMailTeam\DirectMail\Module\ConfigurationController:
     tags: ['backend.controller']
   DirectMailTeam\DirectMail\Module\DmailController:

--- a/Resources/Public/Images/module-directmail.svg
+++ b/Resources/Public/Images/module-directmail.svg
@@ -1,10 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1000px"
-	 height="1000px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">
-<g id="Ebene_1">
-	<rect x="130.5" y="271.5" fill="none" stroke="#FFFFFF" stroke-width="55" stroke-miterlimit="10" width="737" height="461"/>
-	<polyline fill="none" stroke="#FFFFFF" stroke-width="55" stroke-miterlimit="10" points="868,271 499.5,576.587 131,271 	"/>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -4 16 24"><g fill="currentColor"><path d="M1 3.5v9c0 .3.2.5.5.5h13c.3 0 .5-.2.5-.5v-9c0-.3-.2-.5-.5-.5h-13c-.3 0-.5.2-.5.5zM8 10l1.6-1.3 3.8 3.2H2.7l3.8-3.2L8 10zm0-1.3L2.7 4.1h10.7L8 8.7zM2 4.9 5.7 8 2 11.1V4.9zm12 6.2L10.3 8 14 4.9v6.2z"/></g></svg>

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "typo3/cms-core": "^13.4",
     "typo3/cms-dashboard": "^13.4",
     "php": "^8.2 || ^8.3 || ^8.4",
-    "friendsoftypo3/tt-address": "^9.0"
+    "friendsoftypo3/tt-address": "^9.0 || ^10.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '13.4.0-13.4.99',
             'lowlevel' => '13.4.0-13.99.99',
-            'tt_address' => '9.0.0-9.0.99',
+            'tt_address' => '9.0.0-10.0.99',
             'php' => '8.2.0-8.4.99',
         ],
         'conflicts' => [


### PR DESCRIPTION
This PR adds patches for v12 that are missing in your v13 (PR #538)

https://github.com/kartolo/direct_mail/pull/527

https://github.com/kartolo/direct_mail/pull/532 (fixed for html, but not for plain)

https://github.com/kartolo/direct_mail/pull/534

https://github.com/kartolo/direct_mail/pull/541

Additional:
- add new backend module group icon
- fixes https://github.com/TYPO3-directmail/direct_mail/issues/401
- allow tt_address v10
- refactor SchedulerUtility for TYPO3 13.4.31 (Thanks to https://github.com/Gregor-Agnes/direct_mail_v13/commit/83149f0342063ae0a4b2070326fda2c2d0a7690d)